### PR TITLE
Allow to log to a file via BufWriter

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -29,7 +29,7 @@ dependencies = [
 
 [[package]]
 name = "hilog"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "arc-swap",
  "env_filter",
@@ -54,9 +54,9 @@ checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
 
 [[package]]
 name = "memchr"
-version = "2.7.4"
+version = "2.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
+checksum = "32a282da65faaf38286cf3be983213fcf1d2e2a58700e808f83f4ea9a4804bc0"
 
 [[package]]
 name = "regex"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hilog"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 rust-version = "1.78.0"
 license = "Apache-2.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -250,6 +250,7 @@ impl Logger {
     }
 
     /// Sets a file for which the log messages will also be written to.
+    ///
     /// The format of the log messages will be similar to env_logger but skipping the time stamp.
     /// This will use the same set of filters as given by set_filter.
     pub fn set_file_writer(&self, path: PathBuf) -> std::io::Result<()> {
@@ -320,7 +321,7 @@ impl Log for Logger {
 
         if self
             .file_writer_enabled
-            .load(std::sync::atomic::Ordering::Acquire)
+            .load(std::sync::atomic::Ordering::Relaxed)
         {
             if let Some(ref mut writer) = *self.file_writer.lock().unwrap() {
                 let _ = writeln!(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,7 +2,7 @@
 //!
 //! This crate is in its very early stages and still under development,
 //! it was partially inspired by [`env_logger`].
-//! 
+//!
 //! ## Features
 //! - Permits filtering based on the [`env_filter`] spec via the crate.
 //! - Permits dynamic replacement of filters in an atomic manner, making changes
@@ -11,7 +11,7 @@
 //!
 //! [`env_logger`]: https://docs.rs/env_logger/latest/env_logger/
 //! [`env_filter`]: https://docs.rs/env_filter/latest/env_filter/
-//! 
+//!
 
 mod hilog_writer;
 
@@ -22,8 +22,13 @@ use log::{LevelFilter, Log, Metadata, Record, SetLoggerError};
 use std::ffi::CStr;
 use std::fmt;
 use std::fmt::Write;
+use std::fs::File;
+use std::io::BufWriter;
+use std::io::Write as OtherWrite;
 use std::mem::MaybeUninit;
-use std::sync::Arc;
+use std::path::PathBuf;
+use std::sync::atomic::AtomicBool;
+use std::sync::Mutex;
 
 pub(crate) type FormatFn = Box<dyn Fn(&mut dyn fmt::Write, &Record) -> fmt::Result + Sync + Send>;
 
@@ -211,6 +216,8 @@ impl Builder {
             tag: self.log_tag.take(),
             filter: ArcSwap::from_pointee(self.filter.build()),
             custom_format: self.custom_format.take(),
+            file_writer_enabled: AtomicBool::new(false),
+            file_writer: Mutex::new(None),
         }
     }
 }
@@ -220,6 +227,8 @@ pub struct Logger {
     tag: Option<String>,
     filter: ArcSwap<Filter>,
     custom_format: Option<FormatFn>,
+    file_writer_enabled: AtomicBool,
+    file_writer: Mutex<Option<BufWriter<File>>>,
 }
 
 use hilog_writer::HiLogWriter;
@@ -238,6 +247,18 @@ impl Logger {
 
     pub fn set_filter(&self, filter: Filter) {
         self.filter.store(filter.into());
+    }
+
+    /// Sets a file for which the log messages will also be written to.
+    /// The format of the log messages will be similar to env_logger but skipping the time stamp.
+    /// This will use the same set of filters as given by set_filter.
+    pub fn set_file_writer(&self, path: PathBuf) -> std::io::Result<()> {
+        let f = std::fs::File::create(path)?;
+        let b = BufWriter::new(f);
+        *self.file_writer.lock().unwrap() = Some(b);
+        self.file_writer_enabled
+            .store(true, std::sync::atomic::Ordering::Release);
+        Ok(())
     }
 
     fn is_loggable(&self, tag: &CStr, level: LogLevel) -> bool {
@@ -296,7 +317,32 @@ impl Log for Logger {
         };
 
         writer.flush();
+
+        if self
+            .file_writer_enabled
+            .load(std::sync::atomic::Ordering::Acquire)
+        {
+            if let Some(ref mut writer) = *self.file_writer.lock().unwrap() {
+                let _ = writeln!(
+                    writer,
+                    "[{} {}] {}",
+                    record.level(),
+                    record.module_path().unwrap_or(""),
+                    record.args()
+                );
+            }
+        }
     }
 
-    fn flush(&self) {}
+    fn flush(&self) {
+        let mut error_occured = false;
+        if let Some(ref mut writer) = *self.file_writer.lock().unwrap() {
+            if writer.flush().is_err() {
+                error_occured = true;
+            }
+        }
+        if error_occured {
+            *self.file_writer.lock().unwrap() = None;
+        }
+    }
 }


### PR DESCRIPTION
Allows to log to a file in addition to the normal log output.
The file output log is similar to env_logger but slightly different.
The logger has a global filter which is respected by both.

Additionally, I updated the dependencies and bumped the version number because this PR is quite small.


Signed-off-by: Narfinger <Narfinger@users.noreply.github.com>
