### PR TITLE
Use the target instead of module so that filtering works

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -29,7 +29,7 @@ dependencies = [
 
 [[package]]
 name = "hilog"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "arc-swap",
  "env_filter",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hilog"
-version = "0.2.1"
+version = "0.2.2"
 edition = "2021"
 rust-version = "1.78.0"
 license = "Apache-2.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -328,7 +328,7 @@ impl Log for Logger {
                     writer,
                     "[{} {}] {}",
                     record.level(),
-                    record.module_path().unwrap_or(""),
+                    record.target(),
                     record.args()
                 );
             }


### PR DESCRIPTION
Use target instead of module.
The documentation is a bit confusing but target is allowed to be given by the log! statement so it makes sense to be able to filter on that.

